### PR TITLE
修改多行文本框的换行规则

### DIFF
--- a/src/app/views/NewImage.vue
+++ b/src/app/views/NewImage.vue
@@ -108,8 +108,13 @@
           <p class="sub-title-info">必须创建 /workspace 目录，此目录将自动挂载到实例的文件根目录</p>
         </div>
         <div class="row-mt">
-          <el-input type="textarea" :rows="14" placeholder="必填，请输入内容" v-model="dockerFile">
-          </el-input>
+          <el-input 
+            type="textarea" 
+            :rows="14" 
+            placeholder="必填，请输入内容" 
+            v-model="dockerFile"
+            style="word-break: break-all"
+          ></el-input>
         </div>
         <div class="sub-title row-mt">
           <p class="sub-title-title">创建后的镜像名与版本标识</p>


### PR DESCRIPTION
默认为便于文章阅读，会不在单词内换行，自动在单词前、”-“符号后换行。但在排版代码等时，反而会出现行尾单独悬挂”-“符号的问题。故改为强制在单词内换行，以防止浏览器错误得将“-”认成断字符而换行。