### PR TITLE
修复构建时报错

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,6 @@
+{
+ "plugins": [
+    "@babel/plugin-proposal-nullish-coalescing-operator",
+    "@babel/plugin-proposal-optional-chaining"
+  ]
+}


### PR DESCRIPTION
开启了Babel的两个语法插件来修复构建时出现的报错