### PR TITLE
Feat: Dockerfile ubuntu 可设置时区,默认东八区

### DIFF
--- a/src/app/views/NewImage.vue
+++ b/src/app/views/NewImage.vue
@@ -226,8 +226,10 @@ WORKDIR /workspace
       }
       if (type === 3) {
         this.dockerFile = `FROM ubuntu:18.04
+ENV TZ=Asia/Shanghai
 RUN mkdir -p /workspace
-RUN apt -y update && apt -y install openssl
+RUN apt -y update && apt -y install openssl && DEBIAN_FRONTEND="noninteractive" apt -y install tzdata
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 WORKDIR /workspace
 `;
         this.name = "mcsm-ubuntu";


### PR DESCRIPTION
Dockerfile ubuntu 重写为:
FROM ubuntu:18.04
ENV TZ=Asia/Shanghai
RUN mkdir -p /workspace
RUN apt -y update && apt -y install openssl && DEBIAN_FRONTEND="noninteractive" apt -y install tzdata
RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
WORKDIR /workspace
可设置时区