### PR TITLE
修复Ubuntu的docker镜像

### DIFF
--- a/src/app/views/NewImage.vue
+++ b/src/app/views/NewImage.vue
@@ -227,9 +227,9 @@ WORKDIR /workspace
       if (type === 3) {
         this.dockerFile = `FROM ubuntu:18.04
 ENV TZ=Asia/Shanghai
-RUN mkdir -p /workspace
-RUN apt -y update && apt -y install openssl && DEBIAN_FRONTEND="noninteractive" apt -y install tzdata
+RUN apt update && apt -y install openssl libcurl4 && DEBIAN_FRONTEND="noninteractive" apt -y install tzdata
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN mkdir -p /workspace
 WORKDIR /workspace
 `;
         this.name = "mcsm-ubuntu";


### PR DESCRIPTION
修复了Ubuntu镜像无法开启基岩版服务器的问题